### PR TITLE
fix: reset pluginInitFuncs on initialization

### DIFF
--- a/apid.go
+++ b/apid.go
@@ -50,7 +50,7 @@ func Initialize(s Services) {
 	ss.api = s.API()
 	ss.data = s.Data()
 
-	pluginInitFuncs = make([]PluginInitFunc, 1)
+	pluginInitFuncs = make([]PluginInitFunc, 0)
 
 	ss.events.Emit(SystemEventsSelector, APIDInitializedEvent)
 }

--- a/apid.go
+++ b/apid.go
@@ -50,6 +50,8 @@ func Initialize(s Services) {
 	ss.api = s.API()
 	ss.data = s.Data()
 
+	pluginInitFuncs = make([]PluginInitFunc, 1)
+
 	ss.events.Emit(SystemEventsSelector, APIDInitializedEvent)
 }
 


### PR DESCRIPTION
Initialize should make sure that pluginInitFuncs slice is cleared