### PR TITLE
Apirt 4751 - (use shared cache mode)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.x
+  - 1.8.3
 
 before_install:
   - sudo add-apt-repository ppa:masterminds/glide -y

--- a/data/data.go
+++ b/data/data.go
@@ -62,7 +62,7 @@ func CreateDataService() apid.DataService {
 	dbTraceLog = apid.Log().ForModule("data_trace")
 
 	config.SetDefault(configDataDriverKey, "sqlite3")
-	config.SetDefault(configDataSourceKey, "%s")
+	config.SetDefault(configDataSourceKey, "file:%s")
 	config.SetDefault(configDataPathKey, "sqlite")
 
 	return &dataService{}

--- a/data/data.go
+++ b/data/data.go
@@ -38,7 +38,7 @@ const (
 	statCollectionInterval = 10
 	commonDBID             = "common"
 	commonDBVersion        = "base"
-
+	dbOpenMode             = "?cache=shared&mode=rwc"
 	defaultTraceLevel = "warn"
 )
 
@@ -62,7 +62,7 @@ func CreateDataService() apid.DataService {
 	dbTraceLog = apid.Log().ForModule("data_trace")
 
 	config.SetDefault(configDataDriverKey, "sqlite3")
-	config.SetDefault(configDataSourceKey, "file:%s")
+	config.SetDefault(configDataSourceKey, "%s")
 	config.SetDefault(configDataPathKey, "sqlite")
 
 	return &dataService{}

--- a/data/data.go
+++ b/data/data.go
@@ -145,7 +145,7 @@ func (d *dataService) dbVersionForID(id, version string) (db *sql.DB, err error)
 
 	log.Infof("LoadDB: %s", dataPath)
 	source := fmt.Sprintf(config.GetString(configDataSourceKey), dataPath)
-
+	source += dbOpenMode
 	wrappedDriverName := "dd:" + config.GetString(configDataDriverKey)
 	driver := wrap.NewDriver(&sqlite3.SQLiteDriver{}, dbTraceLog)
 	func() {

--- a/data/data_suite_test.go
+++ b/data/data_suite_test.go
@@ -18,11 +18,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
 	"github.com/30x/apid-core"
 	"github.com/30x/apid-core/factory"
 	"io/ioutil"
 	"os"
+	"testing"
 )
 
 var tmpDir string

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -17,14 +17,12 @@ package data_test
 import (
 	"fmt"
 	"github.com/30x/apid-core"
+	"github.com/30x/apid-core/data"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"log"
 	"math/rand"
 	"strconv"
 	"time"
-	"github.com/30x/apid-core/data"
-	"database/sql"
 )
 
 const (
@@ -35,7 +33,7 @@ const (
 )
 
 var (
-	r      *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	r *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 var _ = Describe("Data Service", func() {
@@ -77,94 +75,95 @@ var _ = Describe("Data Service", func() {
 		Expect(err).NotTo(HaveOccurred())
 		setup(db)
 		id := data.VersionedDBID("release", "version")
-		sqlDB := db.(*sql.DB)
-		Expect(sqlDB.Stats().OpenConnections).To(Equal(1))
+		Expect(db.Stats().OpenConnections).To(Equal(1))
 		// run finalizer
-		data.Delete(id).(func(db *sql.DB))(sqlDB)
-		Expect(sqlDB.Stats().OpenConnections).To(Equal(0))
+		data.Delete(id).(func(db *data.ApidDb))(db.(*data.ApidDb))
+		Expect(db.Stats().OpenConnections).To(Equal(0))
 		Expect(data.DBPath(id)).ShouldNot(BeAnExistingFile())
 	})
 
-	It("should handle multi-threaded access", func(done Done) {
+	It("should handle concurrent read & serialized write", func() {
 		db, err := apid.Data().DBForID("test")
 		Expect(err).NotTo(HaveOccurred())
 		setup(db)
-		finished := make(chan struct{})
+		finished := make(chan bool, count+1)
 
 		go func() {
 			for i := 0; i < count; i++ {
 				write(db, i)
 			}
-			finished <- struct{}{}
+			finished <- true
 		}()
 
-		go func() {
-			for i := 0; i < count; i++ {
-				go func() {
-					read(db)
-					finished <- struct{}{}
-				}()
-				time.Sleep(time.Duration(r.Intn(2)) * time.Millisecond)
-			}
-		}()
+		for i := 0; i < count; i++ {
+			go func() {
+				read(db)
+				finished <- true
+			}()
+		}
 
 		for i := 0; i < count+1; i++ {
 			<-finished
 		}
+	}, 10)
 
-		close(done)
+	It("should handle concurrent write", func() {
+		db, err := apid.Data().DBForID("test_write")
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		finished := make(chan bool, count)
+
+		for i := 0; i < count; i++ {
+			go func() {
+				write(db, i)
+				finished <- true
+			}()
+		}
+
+		for i := 0; i < count; i++ {
+			<-finished
+		}
 	}, 10)
 })
 
 func setup(db apid.DB) {
 	_, err := db.Exec(setupSql)
-	if err != nil {
-		log.Fatal(err)
-	}
+	Expect(err).Should(Succeed())
 	tx, err := db.Begin()
-	if err != nil {
-		log.Fatal(err)
-	}
+	Expect(err).Should(Succeed())
 	for i := 0; i < count; i++ {
 		_, err := tx.Exec("INSERT INTO test_2 (counter) VALUES (?);", strconv.Itoa(i))
-		if err != nil {
-			log.Fatalf("filling up test_2 table failed. Exec error=%s", err)
-		}
+		Expect(err).Should(Succeed())
 	}
-	tx.Commit()
+	Expect(tx.Commit()).Should(Succeed())
 }
 
 func read(db apid.DB) {
+	defer GinkgoRecover()
 	var counter string
 	rows, err := db.Query(`SELECT counter FROM test_2 LIMIT 5`)
-	if err != nil {
-		log.Fatalf("test_2 select failed. Exec error=%s", err)
-	} else {
-		defer rows.Close()
-		for rows.Next() {
-			rows.Scan(&counter)
-			//fmt.Print("*")
-		}
+	Expect(err).Should(Succeed())
+	defer rows.Close()
+	for rows.Next() {
+		rows.Scan(&counter)
 	}
 	fmt.Print(".")
 }
 
 func write(db apid.DB, i int) {
-
+	defer GinkgoRecover()
 	// DB INSERT as a txn
 	tx, err := db.Begin()
+	Expect(err).Should(Succeed())
 	defer tx.Rollback()
-	if err != nil {
-		log.Fatalf("Write failed. Exec error=%s", err)
-	}
 	prep, err := tx.Prepare("INSERT INTO test_1 (counter) VALUES ($1);")
-	_, err = tx.Stmt(prep).Exec(strconv.Itoa(i))
-	if err != nil {
-		log.Fatalf("Write failed. Exec error=%s", err)
-	}
-	prep.Close()
-	tx.Commit()
+	Expect(err).Should(Succeed())
+	_, err = prep.Exec(strconv.Itoa(i))
+	Expect(err).Should(Succeed())
+	Expect(prep.Close()).Should(Succeed())
+	Expect(tx.Commit()).Should(Succeed())
 	// DB INSERT directly, not via a txn
-	db.Exec("INSERT INTO test_1 (counter) VALUES ($?)", i + 10000)
+	//_, err = db.Exec("INSERT INTO test_1 (counter) VALUES ($?)", i+10000)
+	//Expect(err).Should(Succeed())
 	fmt.Print("+")
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	count    = 2000
+	count    = 5000
 	setupSql = `
 		CREATE TABLE test_1 (id INTEGER PRIMARY KEY, counter TEXT);
 		CREATE TABLE test_2 (id INTEGER PRIMARY KEY, counter TEXT);`
@@ -150,6 +150,8 @@ func read(db apid.DB) {
 }
 
 func write(db apid.DB, i int) {
+
+	// DB INSERT as a txn
 	tx, err := db.Begin()
 	defer tx.Rollback()
 	if err != nil {
@@ -162,5 +164,7 @@ func write(db apid.DB, i int) {
 	}
 	prep.Close()
 	tx.Commit()
+	// DB INSERT directly, not via a txn
+	db.Exec("INSERT INTO test_1 (counter) VALUES ($?)", i + 10000)
 	fmt.Print("+")
 }

--- a/data_service.go
+++ b/data_service.go
@@ -15,6 +15,7 @@
 package apid
 
 import (
+	"context"
 	"database/sql"
 )
 
@@ -37,9 +38,24 @@ type DB interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
-	Begin() (*sql.Tx, error)
-
+	Begin() (Tx, error)
+	Stats() sql.DBStats
 	//Close() error
 	//Stats() sql.DBStats
 	//Driver() driver.Driver
+}
+
+type Tx interface {
+	Commit() error
+	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Prepare(query string) (*sql.Stmt, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	Rollback() error
+	Stmt(stmt *sql.Stmt) *sql.Stmt
+	StmtContext(ctx context.Context, stmt *sql.Stmt) *sql.Stmt
 }


### PR DESCRIPTION
Latency without fix:
==================
Benchmarking localhost (be patient)
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests


Server Software:
Server Hostname:        localhost
Server Port:            9090

Document Path:          /verifiers/apikey
Document Length:        1287 bytes

Concurrency Level:      10000
Time taken for tests:   27.826 seconds
Complete requests:      10000
Failed requests:        0
Write errors:           0
Total transferred:      13970000 bytes
Total body sent:        4200000
HTML transferred:       12870000 bytes
Requests per second:    359.37 [#/sec] (mean)
Time per request:       27826.464 [ms] (mean)
Time per request:       2.783 [ms] (mean, across all concurrent requests)
Transfer rate:          490.27 [Kbytes/sec] received
                        147.40 kb/s sent
                        637.67 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0 1067 1826.4    271    7248
Processing:     6 3088 3633.8   2162   26766
Waiting:        2 3081 3635.0   2162   26766
Total:          6 4155 3901.6   3590   27792

Percentage of the requests served within a certain time (ms)
  50%   3590
  66%   4181
  75%   4428
  80%   4803
  90%   8937
  95%  14351
  98%  15050
  99%  15133
 100%  27792 (longest request)

Latency with Fix:
==============
Benchmarking localhost (be patient)
Completed 1000 requests
Completed 2000 requests
Completed 3000 requests
Completed 4000 requests
Completed 5000 requests
Completed 6000 requests
Completed 7000 requests
Completed 8000 requests
Completed 9000 requests
Completed 10000 requests
Finished 10000 requests


Server Software:
Server Hostname:        localhost
Server Port:            9090

Document Path:          /verifiers/apikey
Document Length:        1287 bytes

Concurrency Level:      10000
Time taken for tests:   16.808 seconds
Complete requests:      10000
Failed requests:        0
Write errors:           0
Total transferred:      13970000 bytes
Total body sent:        4200000
HTML transferred:       12870000 bytes
Requests per second:    594.95 [#/sec] (mean)
Time per request:       16808.011 [ms] (mean)
Time per request:       1.681 [ms] (mean, across all concurrent requests)
Transfer rate:          811.67 [Kbytes/sec] received
                        244.02 kb/s sent
                        1055.70 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0 2183 2401.4   1075    7257
Processing:    42 9252 3884.6   9245   16503
Waiting:        2 9250 3887.0   9245   16502
Total:         89 11435 4174.6  12528   16786

Percentage of the requests served within a certain time (ms)
  50%  12528
  66%  14050
  75%  14793
  80%  15166
  90%  15927
  95%  16249
  98%  16423
  99%  16498
 100%  16786 (longest request)