### PR TITLE
add tests for currently alter table and read table

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -64,7 +64,7 @@ func (d *ApidDb) Ping() error {
 }
 
 func (d *ApidDb) SetMaxIdleConns(n int) {
-	 d.db.SetMaxIdleConns(n)
+	d.db.SetMaxIdleConns(n)
 }
 
 func (d *ApidDb) SetMaxOpenConns(n int) {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Data Service", func() {
 
 		for i := 0; i < alterCount; i++ {
 			go func(j int) {
-				alter(db, j)
+				alter(db, j, "test_1")
 				finished <- true
 			}(i)
 		}
@@ -186,12 +186,12 @@ var _ = Describe("Data Service", func() {
 		setup(db)
 		alterCount := 50
 		for i := 0; i < alterCount; i++ {
-			alter(db, i)
+			alter(db, i, "test_1")
 			read(db)
 		}
 	}, 10)
 
-	It("should handle concurrent read & alter table", func() {
+	It("concurrent read & alter the same table ", func() {
 		db, err := apid.Data().DBForID("test_conn_read_alter")
 		db.SetMaxOpenConns(10)
 		db.SetMaxIdleConns(10)
@@ -201,7 +201,34 @@ var _ = Describe("Data Service", func() {
 		finished := make(chan bool, count+alterCount)
 		for i := 0; i < alterCount; i++ {
 			go func(j int) {
-				alter(db, j)
+				alter(db, j, "test_1")
+				finished <- true
+			}(i)
+		}
+
+		for i := 0; i < count; i++ {
+			go func() {
+				read(db)
+				finished <- true
+			}()
+		}
+
+		for i := 0; i < count+alterCount; i++ {
+			<-finished
+		}
+	}, 10)
+
+	It("concurrent read & alter different tables", func() {
+		db, err := apid.Data().DBForID("test_conn_read_alter_diff_table")
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		alterCount := 50
+		finished := make(chan bool, count+alterCount)
+		for i := 0; i < alterCount; i++ {
+			go func(j int) {
+				alter(db, j, "test_2")
 				finished <- true
 			}(i)
 		}
@@ -234,7 +261,7 @@ func setup(db apid.DB) {
 func read(db apid.DB) {
 	defer GinkgoRecover()
 	var counter string
-	rows, err := db.Query(`SELECT counter FROM test_2 LIMIT 5`)
+	rows, err := db.Query(`SELECT counter FROM test_1 LIMIT 5`)
 	Expect(err).Should(Succeed())
 	defer rows.Close()
 	for rows.Next() {
@@ -261,13 +288,13 @@ func write(db apid.DB, i int) {
 	fmt.Print("+")
 }
 
-func alter(db apid.DB, i int) {
+func alter(db apid.DB, i int, tableName string) {
 	defer GinkgoRecover()
 	// DB INSERT as a txn
 	tx, err := db.Begin()
 	Expect(err).Should(Succeed())
 	defer tx.Rollback()
-	prep, err := tx.Prepare("ALTER TABLE test_1 ADD COLUMN colname_" + strconv.Itoa(i) + " text DEFAULT ''")
+	prep, err := tx.Prepare("ALTER TABLE " + tableName + " ADD COLUMN colname_" + strconv.Itoa(i) + " text DEFAULT ''")
 	Expect(err).Should(Succeed())
 	_, err = prep.Exec()
 	Expect(err).Should(Succeed())

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -119,16 +119,102 @@ var _ = Describe("Data Service", func() {
 		finished := make(chan bool, count)
 
 		for i := 0; i < count; i++ {
-			go func() {
-				write(db, i)
+			go func(j int) {
+				write(db, j)
 				finished <- true
-			}()
+			}(i)
 		}
 
 		for i := 0; i < count; i++ {
 			<-finished
 			// Only one connection should get opened, as connections are serialized.
 			Expect(db.Stats().OpenConnections).To(Equal(1))
+		}
+	}, 10)
+
+	It("should handle concurrent read & write", func() {
+		db, err := apid.Data().DBForID("test_read_write")
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		finished := make(chan bool, 2*count)
+
+		for i := 0; i < count; i++ {
+			go func(j int) {
+				write(db, j)
+				finished <- true
+			}(i)
+			go func() {
+				read(db)
+				finished <- true
+			}()
+		}
+
+		for i := 0; i < 2*count; i++ {
+			<-finished
+		}
+	}, 10)
+
+	It("should handle concurrent alter table by seralizing them", func() {
+		db, err := apid.Data().DBForID("test_alter")
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		alterCount := 50
+		finished := make(chan bool, alterCount)
+
+		for i := 0; i < alterCount; i++ {
+			go func(j int) {
+				alter(db, j)
+				finished <- true
+			}(i)
+		}
+
+		for i := 0; i < alterCount; i++ {
+			<-finished
+			Expect(db.Stats().OpenConnections).To(Equal(1))
+		}
+	}, 10)
+
+	It("should handle seralized read & alter table", func() {
+		db, err := apid.Data().DBForID("test_read_alter")
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		alterCount := 50
+		for i := 0; i < alterCount; i++ {
+			alter(db, i)
+			read(db)
+		}
+	}, 10)
+
+	It("should handle concurrent read & alter table", func() {
+		db, err := apid.Data().DBForID("test_conn_read_alter")
+		db.SetMaxOpenConns(10)
+		db.SetMaxIdleConns(10)
+		Expect(err).NotTo(HaveOccurred())
+		setup(db)
+		alterCount := 50
+		finished := make(chan bool, count+alterCount)
+		for i := 0; i < alterCount; i++ {
+			go func(j int) {
+				alter(db, j)
+				finished <- true
+			}(i)
+		}
+
+		for i := 0; i < count; i++ {
+			go func() {
+				read(db)
+				finished <- true
+			}()
+		}
+
+		for i := 0; i < count+alterCount; i++ {
+			<-finished
 		}
 	}, 10)
 })
@@ -172,5 +258,20 @@ func write(db apid.DB, i int) {
 	// DB INSERT directly, not via a txn
 	//_, err = db.Exec("INSERT INTO test_1 (counter) VALUES ($?)", i+10000)
 	//Expect(err).Should(Succeed())
+	fmt.Print("+")
+}
+
+func alter(db apid.DB, i int) {
+	defer GinkgoRecover()
+	// DB INSERT as a txn
+	tx, err := db.Begin()
+	Expect(err).Should(Succeed())
+	defer tx.Rollback()
+	prep, err := tx.Prepare("ALTER TABLE test_1 ADD COLUMN colname_" + strconv.Itoa(i) + " text DEFAULT ''")
+	Expect(err).Should(Succeed())
+	_, err = prep.Exec()
+	Expect(err).Should(Succeed())
+	Expect(prep.Close()).Should(Succeed())
+	Expect(tx.Commit()).Should(Succeed())
 	fmt.Print("+")
 }


### PR DESCRIPTION
4 tests are failing.

- 2 failures are because of conn read&write on the same table.
**Currently our implementation cannot handle concurrent read/write on the same table.**
I've added tests of concurrent read/write on the same table, and the 2 tests failed.
The solution is here:
https://github.com/30x/apid-core/pull/18

- The last 2 tests are failing with the error we observed:
**<sqlite3.Error>: {
          Code: 6,
          ExtendedCode: 262,
          err: "database schema is locked: main",
      }
      database schema is locked: main**
Looks like Sqlite is not able to handle concurrent alter table & read/write table, because during alter table the "db schema is locked".
 **This lock is db-schema-level, not table-level. Even if your `read` table1 while `alter` table 2, it still has this error.**
What we need to do is:
Implement and try read-only transaction.
Make sure we do ALTER TABLE exclusively (no read/write is allowed when we do ALTER TABLE).
