### PR TITLE
[ISSUE-67600349] Add UUID utils to apid-core

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -24,6 +24,8 @@ import:
   version: v1.3.0
 - package: github.com/apid/goscaffold
   version: master
+- package: github.com/google/uuid
+  version: v0.2
 testImport:
 - package: github.com/onsi/ginkgo/ginkgo
 - package: github.com/onsi/gomega

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"github.com/google/uuid"
+)
+
+func IsValidUUID(id string) bool {
+	_, err := uuid.Parse(id)
+	return err == nil
+}
+
+func GenerateUUID() string {
+	return uuid.New().String()
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/apid/apid-core/util"
+	"regexp"
+	"testing"
+)
+
+var _ = BeforeSuite(func() {
+})
+
+func TestEvents(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}
+
+var _ = Describe("APID utils", func() {
+
+	Context("UUID", func() {
+		It("should validate UUID", func() {
+			data := []string{
+				"fc041ed2-62a7-4086-a66e-bbbc9219fad5",
+				"invalid-uuid",
+			}
+			expected := []bool{
+				true,
+				false,
+			}
+
+			for i := range data {
+				Ω(util.IsValidUUID(data[i])).Should(Equal(expected[i]))
+			}
+
+		})
+
+		It("should generate valid UUID", func() {
+			r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$")
+			Ω(r.MatchString(util.GenerateUUID())).Should(BeTrue())
+			Ω(util.IsValidUUID(util.GenerateUUID())).Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
@sramamoorthy73 suggested put UUID validation into apid-core so all plugins can make use of it.
Currently more than 1 plugins need  UUID validation/generation for request-validation/testing.
Other util functions can be also put into this util.go
These 2 funcs are just wrappers of github.com/google/uuid
This also resolves the TODO here:
https://github.com/apid/apidApigeeSync/blob/master/data.go#L544