### PR TITLE
b/68272561  Add generic "sql.rows->[]struct" mapping to apid-core

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -18,14 +18,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"github.com/Sirupsen/logrus"
 	"github.com/apid/apid-core"
 	"github.com/apid/apid-core/api"
 	"github.com/apid/apid-core/data/wrap"
 	"github.com/apid/apid-core/logger"
-	"github.com/Sirupsen/logrus"
 	"github.com/mattn/go-sqlite3"
 	"os"
 	"path"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -52,6 +53,7 @@ type dbMapInfo struct {
 
 var dbMap = make(map[string]*dbMapInfo)
 var dbMapSync sync.RWMutex
+var tagFieldMapper = make(map[reflect.Type]map[string]string)
 
 type ApidDb struct {
 	db    *sql.DB
@@ -357,4 +359,108 @@ func logDBInfo(versionedId string, db *sql.DB) chan bool {
 		}
 	}()
 	return stop
+}
+
+// StructsFromRows fill the dest slice with the values of according rows.
+// Each row is marshaled into a struct. The "db" tag in the struct is used for field mapping.
+// It will take care of null value. The supported type mappings from Sqlite3 to Go are:
+// text->string; integer->int64; float->float64; blob->[]byte/string
+func StructsFromRows(dest interface{}, rows *sql.Rows) error {
+	t := reflect.TypeOf(dest)
+	if t == nil {
+		return nil
+	}
+	// type of the struct
+	t = t.Elem().Elem()
+	//build mapper if not existent
+	m, ok := tagFieldMapper[t]
+	if !ok {
+		m = make(map[string]string)
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			m[f.Tag.Get("db")] = f.Name
+		}
+		tagFieldMapper[t] = m
+	}
+
+	colNames, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	colTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return err
+	}
+
+	cols := make([]interface{}, len(colNames))
+	slice := reflect.New(reflect.SliceOf(t)).Elem()
+
+	for i := range cols {
+		switch colTypes[i].DatabaseTypeName() {
+		case "null":
+			cols[i] = new(sql.NullString)
+		case "text":
+			cols[i] = new(sql.NullString)
+		case "integer":
+			cols[i] = new(sql.NullInt64)
+		case "float":
+			cols[i] = new(sql.NullFloat64)
+		case "blob":
+			cols[i] = new([]byte)
+		default:
+			return fmt.Errorf("unsupprted column type: %s", colTypes[i].DatabaseTypeName())
+		}
+	}
+	for rows.Next() {
+		v := reflect.New(t).Elem()
+		err := rows.Scan(cols...)
+		if err != nil {
+			return err
+		}
+		for i := range cols {
+			switch c := cols[i].(type) {
+			case *sql.NullString:
+				if f := v.FieldByName(m[colNames[i]]); c.Valid && f.IsValid() {
+					if reflect.TypeOf("").AssignableTo(f.Type()) {
+						f.SetString(c.String)
+					} else {
+						return fmt.Errorf("cannot convert column type %s to field type %s",
+							colTypes[i].DatabaseTypeName(), f.Type().String())
+					}
+				}
+			case *sql.NullInt64:
+				if f := v.FieldByName(m[colNames[i]]); c.Valid && f.IsValid() {
+					if reflect.TypeOf(int64(0)).AssignableTo(f.Type()) {
+						f.SetInt(c.Int64)
+					} else {
+						return fmt.Errorf("cannot convert column type %s to field type %s",
+							colTypes[i].DatabaseTypeName(), f.Type().String())
+					}
+				}
+			case *sql.NullFloat64:
+				if f := v.FieldByName(m[colNames[i]]); c.Valid && f.IsValid() {
+					if reflect.TypeOf(float64(0)).AssignableTo(f.Type()) {
+						f.SetFloat(c.Float64)
+					} else {
+						return fmt.Errorf("cannot convert column type %s to field type %s",
+							colTypes[i].DatabaseTypeName(), f.Type().String())
+					}
+				}
+			case *[]byte:
+				if f := v.FieldByName(m[colNames[i]]); f.IsValid() {
+					if reflect.TypeOf(*c).AssignableTo(f.Type()) {
+						f.SetBytes(*c)
+					} else if reflect.TypeOf("").AssignableTo(f.Type()) {
+						f.SetString(string(*c))
+					} else {
+						return fmt.Errorf("cannot convert column type %s to field type %s",
+							colTypes[i].DatabaseTypeName(), f.Type().String())
+					}
+				}
+			}
+		}
+		slice = reflect.Append(slice, v)
+	}
+	reflect.ValueOf(dest).Elem().Set(slice)
+	return nil
 }

--- a/data/data.go
+++ b/data/data.go
@@ -92,6 +92,16 @@ func (d *ApidDb) QueryRow(query string, args ...interface{}) *sql.Row {
 	return d.db.QueryRow(query, args...)
 }
 
+func (d *ApidDb) QueryStructs(dest interface{}, query string, args ...interface{}) error {
+	rows, err := d.db.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	err = StructsFromRows(dest, rows)
+	return err
+}
+
 func (d *ApidDb) Begin() (apid.Tx, error) {
 	d.mutex.Lock()
 	tx, err := d.db.Begin()
@@ -158,6 +168,16 @@ func (tx *Tx) Stmt(stmt *sql.Stmt) *sql.Stmt {
 }
 func (tx *Tx) StmtContext(ctx context.Context, stmt *sql.Stmt) *sql.Stmt {
 	return tx.tx.StmtContext(ctx, stmt)
+}
+
+func (tx *Tx) QueryStructs(dest interface{}, query string, args ...interface{}) error {
+	rows, err := tx.tx.Query(query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	err = StructsFromRows(dest, rows)
+	return err
 }
 
 func CreateDataService() apid.DataService {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Data Service", func() {
 
 		It("StructsFromRows", func() {
 			db.Exec(`
-			CREATE TABLE kms_api_product (
+			CREATE TABLE test_table (
 			id text,
 			quota_interval integer,
 			signed_int integer,
@@ -287,7 +287,7 @@ var _ = Describe("Data Service", func() {
 			not_used text,
 			primary key (id)
 			);
-			INSERT INTO "kms_api_product" VALUES(
+			INSERT INTO "test_table" VALUES(
 			'b7e0970c-4677-4b05-8105-5ea59fdcf4e7',
 			1,
 			-1,
@@ -301,7 +301,7 @@ var _ = Describe("Data Service", func() {
 			0.7,
 			'not_used'
 			);
-			INSERT INTO "kms_api_product" VALUES(
+			INSERT INTO "test_table" VALUES(
 			'a7e0970c-4677-4b05-8105-5ea59fdcf4e7',
 			NULL,
 			NULL,
@@ -318,7 +318,7 @@ var _ = Describe("Data Service", func() {
 			`)
 
 			rows, err := db.Query(`
-			SELECT * from "kms_api_product";
+			SELECT * from "test_table";
 			`)
 			Ω(err).Should(Succeed())
 			defer rows.Close()

--- a/data_service.go
+++ b/data_service.go
@@ -44,6 +44,7 @@ type DB interface {
 	SetConnMaxLifetime(d time.Duration)
 	SetMaxIdleConns(n int)
 	SetMaxOpenConns(n int)
+	QueryStructs(dest interface{}, query string, args ...interface{}) error
 	//Close() error
 	//Stats() sql.DBStats
 	//Driver() driver.Driver
@@ -62,4 +63,5 @@ type Tx interface {
 	Rollback() error
 	Stmt(stmt *sql.Stmt) *sql.Stmt
 	StmtContext(ctx context.Context, stmt *sql.Stmt) *sql.Stmt
+	QueryStructs(dest interface{}, query string, args ...interface{}) error
 }


### PR DESCRIPTION
Example usage:
db table is:
```
			CREATE TABLE test_table (
			id text,
			quota_interval integer,
			signed_int integer,
			sql_int integer,
			created_at blob,
			created_by text,
			updated_at blob,
			string_blob blob,
			ratio float,
			short_float float,
			sql_float float,
			not_used text,
			primary key (id)
			);
```
Code is:
```
		type TestStruct struct {
			Id            string          `db:"id"`
			QuotaInterval int64           `db:"quota_interval"`
			SignedInt     int             `db:"signed_int"`
			SqlInt        sql.NullInt64   `db:"sql_int"`
			Ratio         float64         `db:"ratio"`
			ShortFloat    float32         `db:"short_float"`
			SqlFloat      sql.NullFloat64 `db:"sql_float"`
			CreatedAt     string          `db:"created_at"`
			CreatedBy     sql.NullString  `db:"created_by"`
			UpdatedAt     []byte          `db:"updated_at"`
			StringBlob    sql.NullString  `db:"string_blob"`
			NotInDb       string          `db:"not_in_db"`
			NotUsed       string
		}
```
```
rows, err := db.Query(`SELECT * from "test_table";`)
defer rows.Close()
s := []TestStruct{}
err = data.StructsFromRows(&s, rows)
```
or
```
			s := []TestStruct{}
			err := db.QueryStructs(&s, `
			SELECT * from "test_table";
			`)
```